### PR TITLE
Yaml parse bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,14 @@
             <type>jar</type>
         </dependency>  
           
-        <dependency>
+<!--        <dependency>
             <groupId>org.jyaml</groupId>
             <artifactId>jyaml</artifactId>
             <version>1.3</version>
             <type>jar</type>
-        </dependency>
+        </dependency>-->
+        
+        
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>

--- a/src/main/java/Provisioning/ProvisioningCore.java
+++ b/src/main/java/Provisioning/ProvisioningCore.java
@@ -6,7 +6,6 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -14,7 +13,6 @@ import TunnelConfiguration.EC2TunnelConf;
 import TunnelConfiguration.GENITunnelConf;
 import TunnelConfiguration.TunnelConf;
 import toscaTransfer.Connection;
-import toscaTransfer.Connection.node;
 import toscaTransfer.Topology;
 import toscaTransfer.toscaAddressAnalysis;
 import toscaTransfer.toscaAddressAnalysis.name_address;
@@ -402,7 +400,6 @@ public class ProvisioningCore {
     public static void main(String[] args) {
         // TODO Auto-generated method stub
         currentDir = getCurrentDir();
-        System.out.println(currentDir);
         if (!analysisArgs(args)) {
             System.out.println("Error: argument is wrong!");
             return;

--- a/src/main/java/toscaTransfer/toscaAddressAnalysis.java
+++ b/src/main/java/toscaTransfer/toscaAddressAnalysis.java
@@ -1,13 +1,12 @@
 package toscaTransfer;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.ho.yaml.Yaml;
-import org.ho.yaml.YamlStream;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -32,27 +31,30 @@ public class toscaAddressAnalysis {
     public void generateNameAddress(String toscaFilePath, String topologyName) {
         try {
             File file = new File(toscaFilePath);
-            YamlStream stream = Yaml.loadStream(file);
-            for (Iterator iter = stream.iterator(); iter.hasNext();) {
-                HashMap hashMap = (HashMap) iter.next();
-                for (Iterator iter2 = hashMap.entrySet().iterator(); iter2.hasNext();) {
-                    Map.Entry entry = (Map.Entry) iter2.next();
-                    Object key = entry.getKey();
-                    Object value = entry.getValue();
-                    String keyS = key.toString();
-                    String valueS = value.toString();
-                    String jsonValue = transfer2json(valueS);
-                    if (keyS.equals("components")) {
-                        na = json2NameAddress(jsonValue, topologyName);
-                    }
-                    if (keyS.equals("publicKeyPath")) {
-                        sshKeyPath = valueS;
-                    }
-                    if (keyS.equals("userName")) {
-                        userAccountName = valueS;
-                    }
+//            YamlStream stream = Yaml.loadStream(file);
+            org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml();
+            Map<String, Object> hashMap = (Map<String, Object>) yaml.load(new FileInputStream(file));
+
+//            for (Iterator iter = stream.iterator(); iter.hasNext();) {
+//                HashMap hashMap = (HashMap) iter.next();
+            for (Iterator iter2 = hashMap.entrySet().iterator(); iter2.hasNext();) {
+                Map.Entry entry = (Map.Entry) iter2.next();
+                Object key = entry.getKey();
+                Object value = entry.getValue();
+                String keyS = key.toString();
+                String valueS = value.toString();
+                String jsonValue = transfer2json(valueS);
+                if (keyS.equals("components")) {
+                    na = json2NameAddress(jsonValue, topologyName);
+                }
+                if (keyS.equals("publicKeyPath")) {
+                    sshKeyPath = valueS;
+                }
+                if (keyS.equals("userName")) {
+                    userAccountName = valueS;
                 }
             }
+//            }
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/toscaTransfer/toscaTotalAnalysis.java
+++ b/src/main/java/toscaTransfer/toscaTotalAnalysis.java
@@ -6,12 +6,11 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.ho.yaml.Yaml;
-import org.ho.yaml.YamlStream;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import Provisioning.Logger;
+import java.io.FileInputStream;
 import org.json.JSONException;
 
 public class toscaTotalAnalysis {
@@ -28,26 +27,28 @@ public class toscaTotalAnalysis {
     public void generateTopology(String toscaFilePath) {
         try {
             File file = new File(toscaFilePath);
-            YamlStream stream = Yaml.loadStream(file);
+//            YamlStream stream = Yaml.loadStream(file);
             boolean find_conn = false;
-            for (Iterator iter = stream.iterator(); iter.hasNext();) {
-                HashMap hashMap = (HashMap) iter.next();
-                for (Iterator iter2 = hashMap.entrySet().iterator(); iter2.hasNext();) {
-                    Map.Entry entry = (Map.Entry) iter2.next();
-                    Object key = entry.getKey();
-                    Object value = entry.getValue();
-                    String keyS = key.toString();
-                    String valueS = value.toString();
-                    String jsonValue = transfer2json(valueS);
-                    if (keyS.equals("topologies")) {
-                        topologies = json2topology(jsonValue);
-                    }
-                    if (keyS.equals("connections")) {
-                        connections = json2connection(jsonValue);
-                        find_conn = true;
-                    }
+            org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml();
+            Map<String, Object> hashMap = (Map<String, Object>) yaml.load(new FileInputStream(file));
+//            for (Iterator iter = stream.iterator(); iter.hasNext();) {
+//                HashMap hashMap = (HashMap) iter.next();
+            for (Iterator iter2 = hashMap.entrySet().iterator(); iter2.hasNext();) {
+                Map.Entry entry = (Map.Entry) iter2.next();
+                Object key = entry.getKey();
+                Object value = entry.getValue();
+                String keyS = key.toString();
+                String valueS = value.toString();
+                String jsonValue = transfer2json(valueS);
+                if (keyS.equals("topologies")) {
+                    topologies = json2topology(jsonValue);
+                }
+                if (keyS.equals("connections")) {
+                    connections = json2connection(jsonValue);
+                    find_conn = true;
                 }
             }
+//            }
             if (!find_conn) {
                 connections = new ArrayList<Connection>();
             }


### PR DESCRIPTION
There was a parse exception with the old yaml parser. It seems that the old parser could not handle files with '{,}'